### PR TITLE
Create dummy `want-to-help` and `need-help` endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,16 +1,20 @@
 from flask import Flask, Blueprint
+from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 
-from .api import PaymentResource
+from .api import PaymentResource, WantToHelpResource, NeedHelpResource
 from .config import Config
 
 api = Blueprint('api', __name__)
-api.add_url_rule('/payment/', view_func=PaymentResource.as_view('payment'))
+api.add_url_rule('/payment', view_func=PaymentResource.as_view('payment'))
+api.add_url_rule('/want-to-help', view_func=WantToHelpResource.as_view('want-to-help'))
+api.add_url_rule('/need-help', view_func=NeedHelpResource.as_view('need-help'))
 
 app = Flask(__name__)
+CORS(app)
 app.config.from_object(Config)
-app.register_blueprint(api, url_prefix='/api/v1')
+app.register_blueprint(api, url_prefix='/api')
 
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)

--- a/app/api.py
+++ b/app/api.py
@@ -8,3 +8,13 @@ class PaymentResource(MethodView):
 
     def post(self):
         pass
+
+
+class WantToHelpResource(MethodView):
+    def post(self):
+        return jsonify(ok=True)
+
+
+class NeedHelpResource(MethodView):
+    def post(self):
+        return jsonify(ok=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,6 +41,18 @@ dotenv = ["python-dotenv"]
 
 [[package]]
 category = "main"
+description = "A Flask extension adding a decorator for CORS support"
+name = "flask-cors"
+optional = false
+python-versions = "*"
+version = "3.0.8"
+
+[package.dependencies]
+Flask = ">=0.9"
+Six = "*"
+
+[[package]]
+category = "main"
 description = "SQLAlchemy database migrations for Flask applications using Alembic"
 name = "flask-migrate"
 optional = false
@@ -169,7 +181,7 @@ dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-
 watchdog = ["watchdog"]
 
 [metadata]
-content-hash = "7fd20d69820903ec66eeb9dcc1d22353dddef38b77aa34be2241ab0cd8228bd9"
+content-hash = "2adac0de67117c58d86af6ba9c02ebf675cce81f54b893f75195392e3a08eb3b"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -183,6 +195,10 @@ click = [
 flask = [
     {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
     {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
+]
+flask-cors = [
+    {file = "Flask-Cors-3.0.8.tar.gz", hash = "sha256:72170423eb4612f0847318afff8c247b38bd516b7737adfc10d1c2cdbb382d16"},
+    {file = "Flask_Cors-3.0.8-py2.py3-none-any.whl", hash = "sha256:f4d97201660e6bbcff2d89d082b5b6d31abee04b1b3003ee073a6fd25ad1d69a"},
 ]
 flask-migrate = [
     {file = "Flask-Migrate-2.5.3.tar.gz", hash = "sha256:a69d508c2e09d289f6e55a417b3b8c7bfe70e640f53d2d9deb0d056a384f37ee"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.6"
 flask = "^1.1.2"
 flask-sqlalchemy = "^2.4.1"
 flask-migrate = "^2.5.3"
+flask-cors = "^3.0.8"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Closes #6 

As stated in the title, this PR introduces two dummy endpoints that frontend can start using
Also enables CORS from all domains and routes, which will be handled/restricted in future PR