### PR TITLE
Create new endpoints for querying activities, faculties and skills lists

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,20 +1,25 @@
-from flask import Flask, Blueprint
+from flask import Blueprint, Flask
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 
-from .api import PaymentResource, WantToHelpResource, NeedHelpResource
 from .config import Config
 
-api = Blueprint('api', __name__)
-api.add_url_rule('/payment', view_func=PaymentResource.as_view('payment'))
-api.add_url_rule('/want-to-help', view_func=WantToHelpResource.as_view('want-to-help'))
-api.add_url_rule('/need-help', view_func=NeedHelpResource.as_view('need-help'))
 
 app = Flask(__name__)
 CORS(app)
 app.config.from_object(Config)
-app.register_blueprint(api, url_prefix='/api/v1')
 
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
+
+from .api import PaymentResource, WantToHelpResource, NeedHelpResource, FacultyResource, ActivityResource, SkillResource
+api = Blueprint('api', __name__)
+api.add_url_rule('/payment', view_func=PaymentResource.as_view('payment'))
+api.add_url_rule('/want-to-help', view_func=WantToHelpResource.as_view('want-to-help'))
+api.add_url_rule('/need-help', view_func=NeedHelpResource.as_view('need-help'))
+api.add_url_rule('/faculties', view_func=FacultyResource.as_view('faculties'))
+api.add_url_rule('/activities', view_func=ActivityResource.as_view('activities'))
+api.add_url_rule('/skills', view_func=SkillResource.as_view('skills'))
+
+app.register_blueprint(api, url_prefix='/api/v1')

--- a/app/api.py
+++ b/app/api.py
@@ -2,6 +2,9 @@ from flask import jsonify
 from flask.views import MethodView
 
 
+from .models import Activity, Attribute, AttributeValueList, Skill
+
+
 class PaymentResource(MethodView):
     def get(self):
         return jsonify(ok=True)
@@ -18,3 +21,22 @@ class WantToHelpResource(MethodView):
 class NeedHelpResource(MethodView):
     def post(self):
         return jsonify(ok=True)
+
+
+class FacultyResource(MethodView):
+    def get(self):
+        faculty_attribute = Attribute.query.filter_by(name="Fakulta").one()
+        faculties = AttributeValueList.query.filter_by(attribute_id=faculty_attribute.id).all()
+        return jsonify(faculties)
+
+
+class ActivityResource(MethodView):
+    def get(self):
+        activities = Activity.query.all()
+        return jsonify(activities)
+
+
+class SkillResource(MethodView):
+    def get(self):
+        skills = Skill.query.filter_by(visible=True, validated=True).all()
+        return jsonify(skills)

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 from app import db
+from dataclasses import dataclass
 from datetime import datetime
 
 
@@ -72,7 +73,12 @@ class Attribute(db.Model):
         return f'<Attribute: [id: {self.id}, name: {self.name}, type id: {self.type_id}]>'
 
 
+@dataclass
 class AttributeValueList(db.Model):
+    id: int
+    attribute_id: int
+    value: str
+
     id = db.Column(db.Integer, primary_key=True)
     attribute_id = db.Column(db.Integer, db.ForeignKey('attribute.id'), nullable=False)
     value = db.Column(db.String(50), nullable=False)
@@ -127,7 +133,11 @@ class UserGroup(db.Model):
         return f'<UserGroup: [id: {self.id}, user id: {self.user_id}, group id: {self.group_id}]>'
 
 
+@dataclass
 class Skill(db.Model):
+    id: int
+    name: str
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(50), unique=True, nullable=False)
     visible = db.Column(db.Boolean)
@@ -153,7 +163,12 @@ class SkillUser(db.Model):
         return f'<SkillUser: [id: {self.id}, skill id: {self.skill_id}, user id: {self.user_id}>'
 
 
+@dataclass
 class Activity(db.Model):
+    id: int
+    name: str
+    description: str
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(50), unique=True, nullable=False)
     description = db.Column(db.String(256))

--- a/app/models.py
+++ b/app/models.py
@@ -160,7 +160,7 @@ class SkillUser(db.Model):
     created_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
     def __repr__(self):
-        return f'<SkillUser: [id: {self.id}, skill id: {self.skill_id}, user id: {self.user_id}>'
+        return f'<SkillUser: [id: {self.id}, skill id: {self.skill_id}, user id: {self.user_id}]>'
 
 
 @dataclass
@@ -179,7 +179,7 @@ class Activity(db.Model):
     deleted_at = db.Column(db.DateTime)
 
     def __repr__(self):
-        return f'<Activity: [id: {self.id}, name: {self.name}, description: {self.description}>'
+        return f'<Activity: [id: {self.id}, name: {self.name}, description: {self.description}]>'
 
 
 class SkillActivity(db.Model):
@@ -190,4 +190,4 @@ class SkillActivity(db.Model):
     created_by = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
 
     def __repr__(self):
-        return f'<SkillActivity: [id: {self.id}, skill id: {self.skill_id}, activity id: {self.activity_id}>'
+        return f'<SkillActivity: [id: {self.id}, skill id: {self.skill_id}, activity id: {self.activity_id}]>'


### PR DESCRIPTION
Closes #19 

In this PR, we expose 3 APIs that frontend can call, specifically: `/skills`, `/activities`, `/faculties`. All of these return lists with values corresponding to that endpoint, e.g. result of calling `/faculties` endpoint is 
```c
[
    {
        "attribute_id": 1,
        "id": 1,
        "value": "Lekárska fakulta (LF UK)"
    },
    {
        "attribute_id": 1,
        "id": 2,
        "value": "Právnická fakulta (PraF UK)"
    },
    // and so on
]
```